### PR TITLE
Fix Czech comment typo in run.sh

### DIFF
--- a/onedrive_sync/run.sh
+++ b/onedrive_sync/run.sh
@@ -26,7 +26,7 @@ if [ -z "$LOCAL_DIR" ]; then
   exit 1
 fi
 
-# připrava složek
+# příprava složek
 mkdir -p "$CONF" "$LOCAL_DIR"
 
 # vygeneruj config.ini


### PR DESCRIPTION
## Summary
- fix a typo in `run.sh` comment

## Testing
- `bash -n onedrive_sync/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_684160ed2d108328b25f7b9e92156cc9